### PR TITLE
[fix] 지혜 삭제 취소 시, 모달창만 닫히게 수정

### DIFF
--- a/src/views/IndividualUser/JobPostingDetail.vue
+++ b/src/views/IndividualUser/JobPostingDetail.vue
@@ -26,15 +26,6 @@ export default {
     const formattedStartDate = computed(() => formatDate1(jobposting.value.startDate));
     const formattedEndDate = computed(() => formatDate1(jobposting.value.endDate));
 
-    const onApplyClick = (postId) => {
-      console.log("postId:", postId);
-    };
-
-    const onDeletedClick = () => {
-      modalMessage.value = "채용공고를 삭제하시겠습니까?";
-      showDeleteModal.value = true;
-    };
-
     const jobposting = ref({
       entName: "",
       postTitle: "",
@@ -63,9 +54,6 @@ export default {
           entAddr1: response.data.entAddr1,
           entAddr2: response.data.entAddr2,
         };
-
-        console.log(response);
-        console.log(jobposting.value.entName);
       } catch (error) {
         console.error("채용공고 상세 내용을 불러오지 못했습니다. 다시 시도해 주세요.", error);
       }
@@ -76,6 +64,15 @@ export default {
     });
 
     const showDeleteModal = ref(false);
+    
+    const onApplyClick = (postId) => {
+      console.log("postId:", postId);
+    };
+
+    const onDeletedClick = () => {
+      modalMessage.value = "채용공고를 삭제하시겠습니까?";
+      showDeleteModal.value = true;
+    };
 
     const confirmDelete = async () => {
       try {
@@ -86,8 +83,7 @@ export default {
           }
         });
         console.log("삭제 결과:", response);
-
-        // 확인 버튼 클릭 시, 삭제 후 페이지 리다이렉트
+        
         closeModal(true);
 
       } catch (error) {

--- a/src/views/IndividualUser/WisdomExploreDetail.vue
+++ b/src/views/IndividualUser/WisdomExploreDetail.vue
@@ -73,7 +73,6 @@ export default {
         userFullId.value = response.data.userId;
         userFullName.value = response.data.userName;
         reportedCnt.value = response.data.reportedCnt;
-
       } catch (error) {
         console.error("신고횟수를 불러오지 못했습니다. 다시 시도해 주세요.", error);
       }
@@ -92,21 +91,26 @@ export default {
 
     const confirmDelete = async () => {
       try {
-        const response = await handleApiCall('post', `/admin/knowhow/delete?knowhowId=${wisdom.value.knowhowId}`, null, {
-          'Content-Type': 'application/json'
+        const response = await handleApiCall('post', '/admin/knowhow/delete', null, {
+          params: { knowhowId: wisdom.value.knowhowId },
+          headers: {
+            'Content-Type': 'application/json',
+          }
         });
         console.log("삭제 결과:", response);
 
-        closeModal();
+        closeModal(true);
 
       } catch (error) {
         console.error("지혜를 삭제하지 못했습니다. 다시 시도해 주세요.", error);
       }
     };
 
-    const closeModal = () => {
+    const closeModal = (shouldRedirect = false) => {
       showDeleteModal.value = false;
-      router.push(ROUTES.WISDOM_MANAGEMENT.path);
+      if (shouldRedirect) {
+        router.push(ROUTES.WISDOM_MANAGEMENT.path);
+      }
     };
 
     return {
@@ -174,7 +178,6 @@ export default {
   <modal-popup v-if="modalPopupStatue" @close-modal="closeModal" :modal-message="modalMessage"
     :router-path="ROUTES.WISDOM_MANAGEMENT.path" />
 </template>
-
 
 <style scoped>
 .body {


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 서비스 관리자 지혜 관리 기능입니다.

## 🔗 관련 이슈

- #18 

## ✨ 변경 사항

- 지혜 삭제 확인 모달창 띄워졌을 때, 취소 버튼 누르면 모달창만 닫히게 수정
- 지혜 삭제 후, 지혜 관리 화면으로 이동됐을 때 목록 갱신 안되는 문제 해결

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보
