### PR TITLE
[feat] #2 - 기업회원, 일반유저 탈퇴시 url파라미터를 통해 하나의 .vue파일에서 안내 페이지 처리하도록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 
 
 # Environment variables
-.env
+.env.local
 .env.local
 .env.*.local
 .env.development

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -97,8 +97,8 @@ const router = createRouter({
             component: () => import("@/views/CorporateUser/CorporateUserDelete.vue"),
         },
         {
-            path: ROUTES.USER_DELETE_SUCCESS.path,
-            name: ROUTES.USER_DELETE_SUCCESS.name,
+            path: ROUTES.DELETE_SUCCESS.path,
+            name: ROUTES.DELETE_SUCCESS.name,
             component: () => import("@/views/Common/UserDeleteSuccess.vue"),
         },
         {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -85,9 +85,9 @@ export const ROUTES = {
         name: "CorporateUserDelete",
     },
     // [개인회원, 기업회원] 탈퇴성공
-    USER_DELETE_SUCCESS: {
-        path: "/delete-success",
-        name: "UserDeleteSuccess",
+    DELETE_SUCCESS: {
+        path: "/delete-success/:cat",
+        name: "DeleteSuccess",
     },
     CORPORATE_DELETE_SUCCESS: {
         path: "/corporate-delete-success",

--- a/src/views/Common/UserDeleteSuccess.vue
+++ b/src/views/Common/UserDeleteSuccess.vue
@@ -1,11 +1,14 @@
 <script>
-import {useRouter} from 'vue-router';
-import { ROUTES } from '@/router/routes'
+import {useRouter, useRoute} from 'vue-router';
+import {ROUTES} from '@/router/routes'
 
 export default {
-  name: "UserDeleteSuccess",
+  name: "DeleteSuccess",
   setup() {
     const router = useRouter();
+    const route = useRoute();
+
+    const isIndividual = route.params.type === 'individual';
 
     const onGoToHomeClick = () => {
       router.push(ROUTES.MAIN.path);
@@ -13,6 +16,7 @@ export default {
 
     return {
       onGoToHomeClick,
+      isIndividual,
     };
   },
 };
@@ -21,8 +25,8 @@ export default {
 <template>
   <main class="body">
     <div class="content">
-      <h1>탈퇴가 완료되었습니다.</h1>
-      <p>이용해 주셔서 감사합니다.<br />앞으로 더 나은 서비스를 위해 노력하겠습니다.</p>
+      <h1>{{ isIndividual ? '탈퇴가 완료되었습니다.' : '탈퇴 신청이 완료되었습니다.' }}</h1>
+      <p>이용해 주셔서 감사합니다.<br/>앞으로 더 나은 서비스를 위해 노력하겠습니다.</p>
       <button @click="onGoToHomeClick" class="home-button">홈으로 돌아가기</button>
     </div>
   </main>

--- a/src/views/CorporateUser/CorporateUserDelete.vue
+++ b/src/views/CorporateUser/CorporateUserDelete.vue
@@ -3,6 +3,7 @@ import {ref} from "vue";
 import {ROUTES} from "@/router/routes";
 import {withdrawCorporate} from "@/api/services/authenticationService";
 import {useUserStore} from "@/stores/userStore";
+import router from "@/router";
 
 export default {
   name: "CorporateUserDelete",
@@ -23,6 +24,15 @@ export default {
       isButtonEnabled.value = confirmText.value === REQUIRED_TEXT && password.value.length > 0;
     };
 
+    const moveToSuccessPage = () => {
+      router.push({
+        name: ROUTES.DELETE_SUCCESS.name,
+        params: {
+          cat: 'corporate'
+        },
+      })
+    }
+
     const onWithdraw = async () => {
       if (confirmText.value !== REQUIRED_TEXT) {
         return;
@@ -36,7 +46,7 @@ export default {
         if (response && response.status === 200) {
           await userStore.logout();
           console.log("탈퇴 처리 완료");
-          window.location.href = ROUTES.CORPORATE_DELETE_SUCCESS.path;
+          moveToSuccessPage();
         } else {
           throw new Error('탈퇴 처리 실패');
         }

--- a/src/views/IndividualUser/IndividualUserDelete.vue
+++ b/src/views/IndividualUser/IndividualUserDelete.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { ROUTES } from "@/router/routes";
 import { withdrawIndividual } from '@/api/services/authenticationService';
 import {useUserStore} from "@/stores/userStore";
+import router from "@/router";
 
 export default {
   name: "IndividualUserDelete",
@@ -16,6 +17,15 @@ export default {
     const errorModalStatus = ref(false);
     const REQUIRED_TEXT = '탈퇴하기';
     const isButtonEnabled = ref(false);
+
+    const moveToSuccessPage = () => {
+      router.push({
+        name: ROUTES.DELETE_SUCCESS.name,
+        params: {
+          cat: 'individual'
+        },
+      })
+    }
 
     const validateConfirmText = () => {
       isButtonEnabled.value = confirmText.value === REQUIRED_TEXT;
@@ -33,7 +43,7 @@ export default {
         console.log("탈퇴 API 응답:", response);
         if (response && response.status === 200) {
           console.log("탈퇴 처리 완료");
-          window.location.href = ROUTES.USER_DELETE_SUCCESS.path;
+          moveToSuccessPage();
         } else {
           throw new Error('탈퇴 처리 실패');
         }


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 기업회원, 일반유저 탈퇴시 url파라미터를 통해 하나의 .vue파일에서 안내 페이지 처리하도록 입니다.

## 🔗 관련 이슈

- #2 

## ✨ 변경 사항

- 기업회원, 일반유저 탈퇴시 url파라미터를 통해 하나의 .vue파일에서 안내 페이지 처리하도록

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보

- [추가적인 정보 또는 주의 사항]
