### PR TITLE
[fix] #62 - 존재하지 않는 사용자의 이력서 조회하려고 하는 경우, 예외처리

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -246,6 +246,11 @@ router.beforeEach((to, from, next) => {
 
     const userStore = useUserStore();
 
+    // NotFound로 가는 경우는 리다이렉션 하지 않음
+    if (to.name === 'NotFound') {
+        return next();
+    }
+
     // 로그인한 관리자 사용자의 메인 페이지 리다이렉션
     if (userStore.isLoggedIn &&
         (userStore.userType === USER_TYPES.INFRA_ADMIN || userStore.userType === USER_TYPES.SERVICE_ADMIN)) {

--- a/src/views/CorporateUser/ReadonlyResumePage.vue
+++ b/src/views/CorporateUser/ReadonlyResumePage.vue
@@ -1,7 +1,7 @@
 <script>
 import { ref, onMounted } from "vue";
 import { ROUTES } from "@/router/routes";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { fetchApplicantResume } from "@/api/services/corporateUserService";
 
 export default {
@@ -13,6 +13,7 @@ export default {
   },
   setup() {
     const route = useRoute();
+    const router = useRouter();
 
     const resume = ref({
       userName: "",
@@ -42,6 +43,7 @@ export default {
 
       } catch (error) {
         console.error("fetchResume API 호출 오류:", error);
+        router.push({ name: "NotFound" });
       }
     };
 


### PR DESCRIPTION
## 📜 Pull Request 설명

이 PR은 서비스 관리자 예외 처리입니다.

## 🔗 관련 이슈

- #62 

## ✨ 변경 사항

- 존재하지 않는 사용자의 이력서를 조회하려고 할 때, NotFound 화면으로 이동

## ✅ 확인 사항

- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 커밋 컨벤션에 맞게 메세지를 작성했습니다.

## 🔍 추가 정보
